### PR TITLE
Remove runtime warning

### DIFF
--- a/lib/float-formats/formats.rb
+++ b/lib/float-formats/formats.rb
@@ -137,7 +137,6 @@ Flt.define BinaryFormat, :XS128,
   bias: 128, bias_mode: :fractional_significand,
   hidden_bit: true,
   endianness: :big_endian, round: :half_up,
-  endianness: :big_endian,
   gradual_underflow: false, infinity: false, nan: false
 
 # HP-3000 excess 256 format, HP-Tandem...


### PR DESCRIPTION
Fixes `.../lib/float-formats/formats.rb:139: warning: duplicated key at line 140 ignored: :endianness`